### PR TITLE
fix: fixed a non existing type in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ fn RustIcon(cx: Scope) -> Element {
             width: 30,
             height: 30,
             fill: "black",
-            icon: Icon::FaRust,
+            icon: FaRust,
         }
     })
 }


### PR DESCRIPTION
Just changed a non existing type of Icon::FaRust to the actual FaRust icon.