### PR TITLE
use #[props(extends = GlobalAttributes)]; allow em units for height and weight

### DIFF
--- a/packages/lib/src/icon_component.rs
+++ b/packages/lib/src/icon_component.rs
@@ -21,22 +21,13 @@ pub trait IconShape {
 pub struct IconProps<T: IconShape + Clone + PartialEq + 'static> {
     /// The icon shape to use.
     pub icon: T,
-    /// The height of the `<svg>` element. Defaults to 20. Pass None to omit.
-    #[props(default = Some(20))]
-    pub height: Option<u32>,
-    /// The width of the `<svg>` element. Defaults to 20. Pass None to omit.
-    #[props(default = Some(20))]
-    pub width: Option<u32>,
     /// The color to use for filling the icon. Defaults to "currentColor".
     #[props(default = "currentColor".to_string())]
     pub fill: String,
-    /// An class for the `<svg>` element.
-    #[props(default = "".to_string())]
-    pub class: String,
     /// An accessible, short-text description for the icon.
     pub title: Option<String>,
-    /// The style of the `<svg>` element.
-    pub style: Option<String>,
+    #[props(extends = GlobalAttributes)]
+    attributes: Vec<Attribute>,
 }
 
 /// Icon component which generates SVG elements
@@ -45,10 +36,6 @@ pub fn Icon<T: IconShape + Clone + PartialEq + 'static>(props: IconProps<T>) -> 
     let (fill, stroke, stroke_width) = props.icon.fill_and_stroke(&props.fill);
     rsx!(
         svg {
-            class: "{props.class}",
-            style: props.style,
-            height: props.height.map(|height| height.to_string()),
-            width: props.width.map(|width| width.to_string()),
             view_box: "{props.icon.view_box()}",
             xmlns: "{props.icon.xmlns()}",
             fill,
@@ -56,6 +43,7 @@ pub fn Icon<T: IconShape + Clone + PartialEq + 'static>(props: IconProps<T>) -> 
             stroke_width,
             stroke_linecap: "{props.icon.stroke_linecap()}",
             stroke_linejoin: "{props.icon.stroke_linejoin()}",
+            ..props.attributes,
             if let Some(title_text) = props.title {
                 title { "{title_text}" }
             }


### PR DESCRIPTION
How stated in #77 it is currently not possible to use em at weight/height, since both are of type `Option<u32>`. Using px is not every time a good idea particularly if you use em everywhere else. Be force to use px make for example hard to create a icon with the same height as the text. This pr remove all props and use `#[props(extends = GlobalAttributes)]` instead if possible. This including weight and height and allow to also to use `1em` as width/height now. This also reduce the code a bit.
Using `#[props(extends = GlobalAttributes)]` did also allow to the user to customize the svg with all available attributes, without defining each at the `IconProps` manual.

Sadly this is breaking change, since the type of height/weight had its default value changed.

see also https://docs.rs/dioxus/latest/dioxus/prelude/attr.component.html#extending-elements